### PR TITLE
#61 separated date into Day Month and Year using a dict

### DIFF
--- a/src/python/datapreprocessor/datapreprocessor/datanormaliser.py
+++ b/src/python/datapreprocessor/datapreprocessor/datanormaliser.py
@@ -14,16 +14,40 @@ def clean_minister_column(lines):
             minister_name = l[0]
     return lines
 
+def has_year(newdate):
+    if newdate.year != 1000:
+        return newdate.year
+    else:
+        return None
+
+def has_month(date, newdate):
+    month_info = date.join(re.findall("[a-zA-Z]+", date))
+    if len(month_info) != 0:
+        return newdate.month
+    else:
+        return None
+
+def has_day(date):
+    numbers_present = [int(n) for n in date.split() if n.isdigit()]
+    # if (len(numbers_present) == 2):
+    #     print "new lajaljalsdkfjlasdjfkd"
+    #     print newdate.day
+    #     return newdate.day
+    # else:
+    #     return None
+    if (len(numbers_present) != 2):
+        return None
+
 def clean_dates(lines):
-    # IMPORTANT: This method currently only expects dates of months with or without a year (does not expect days, does not expect empty months !!!)
-    # Edge case not included: Jan/Feb/Mar - we must decide how to handle
+    # IMPORTANT: This method currently only expects dates of months with or without a year (does not expect days)
     # Edge case included: Sept is not recognized so changed to Sep
     SEPT_PATTERN = re.compile("^sept$", flags=re.IGNORECASE) #RegEx to find "Sept" abbreviation
-    DEFAULT = datetime(1000,12,01,0,0)  #Default date for dateutil to fill in missing gaps, year 1000
+    DEFAULT = datetime(1000,12,01)  #Default date for dateutil to fill in missing gaps, year 1000
 
     for idx,line in enumerate(lines):
         date = line[1]
         date = re.sub(SEPT_PATTERN,"Sep",line[1])
+        dateInfo = {}
 
         # parse date using dateutil lib
         try:
@@ -31,23 +55,13 @@ def clean_dates(lines):
         except:
             newdate = ""
 
-        # If no data or date
         if(len(str(newdate))==0 or len(date)==0):
-            datestring="XXXX-XX-XX"
-        else:
-            datestring=""
-            # YEAR - if default then missing
-            if(newdate.year==1000):
-                datestring+="XXXX-"
-            else:
-                datestring+=str(newdate.year)+"-"
-            # MONTH AND DAY - assumed always present and missing respectively (for now)
-            datestring += str(newdate.month).zfill(2) + "-XX"
+            dateInfo = {'Year': None, 'Month': None, 'Day': None}
+            lines[idx][1]=""
+            return lines
 
-        # print date + " parsed: " + str(newdate) + " is " + datestring
-
-        #Replace date in data
-        lines[idx][1]=datestring
+        dateInfo = {'Year': has_year(newdate), 'Month': has_month(date, newdate), 'Day': has_day(date)}
+        lines[idx][1]=dateInfo
 
     return lines
 

--- a/src/python/datapreprocessor/datapreprocessor/datanormaliser.py
+++ b/src/python/datapreprocessor/datapreprocessor/datanormaliser.py
@@ -27,41 +27,30 @@ def has_month(date, newdate):
     else:
         return None
 
-def has_day(date):
+def has_day(date, newdate):
     numbers_present = [int(n) for n in date.split() if n.isdigit()]
-    # if (len(numbers_present) == 2):
-    #     print "new lajaljalsdkfjlasdjfkd"
-    #     print newdate.day
-    #     return newdate.day
-    # else:
-    #     return None
-    if (len(numbers_present) != 2):
+    if (len(numbers_present) == 2):
+        return newdate.day
+    else:
         return None
 
 def clean_dates(lines):
     # IMPORTANT: This method currently only expects dates of months with or without a year (does not expect days)
     # Edge case included: Sept is not recognized so changed to Sep
     SEPT_PATTERN = re.compile("^sept$", flags=re.IGNORECASE) #RegEx to find "Sept" abbreviation
-    DEFAULT = datetime(1000,12,01)  #Default date for dateutil to fill in missing gaps, year 1000
+    DEFAULT = datetime(1000,12,01,0,0)  #Default date for dateutil to fill in missing gaps, year 1000
 
     for idx,line in enumerate(lines):
         date = line[1]
         date = re.sub(SEPT_PATTERN,"Sep",line[1])
         dateInfo = {}
 
-        # parse date using dateutil lib
-        try:
+        if(len(date)==0):
+            lines[idx][1]= {'Year': None, 'Month': None, 'Day': None}
+        else:
             newdate = parse(date.replace("-"," of "),default=DEFAULT,dayfirst=True)
-        except:
-            newdate = ""
-
-        if(len(str(newdate))==0 or len(date)==0):
-            dateInfo = {'Year': None, 'Month': None, 'Day': None}
-            lines[idx][1]=""
-            return lines
-
-        dateInfo = {'Year': has_year(newdate), 'Month': has_month(date, newdate), 'Day': has_day(date)}
-        lines[idx][1]=dateInfo
+            dateInfo = {'Year': has_year(newdate), 'Month': has_month(date, newdate), 'Day': has_day(date, newdate)}
+            lines[idx][1] = dateInfo
 
     return lines
 

--- a/src/python/datapreprocessor/datapreprocessor/datanormaliser.py
+++ b/src/python/datapreprocessor/datapreprocessor/datanormaliser.py
@@ -29,13 +29,13 @@ def has_month(date, newdate):
 
 def has_day(date, newdate):
     numbers_present = [int(n) for n in date.split() if n.isdigit()]
-    if (len(numbers_present) == 2):
+    if ((newdate.year != 1000  and (len(numbers_present) == 2)) or (newdate.year == 1000 and (len(numbers_present) == 1))):
         return newdate.day
     else:
         return None
 
 def clean_dates(lines):
-    # IMPORTANT: This method currently only expects dates of months with or without a year (does not expect days)
+    # IMPORTANT: This method currently only expects dates of months with or without a year
     # Edge case included: Sept is not recognized so changed to Sep
     SEPT_PATTERN = re.compile("^sept$", flags=re.IGNORECASE) #RegEx to find "Sept" abbreviation
     DEFAULT = datetime(1000,12,01,0,0)  #Default date for dateutil to fill in missing gaps, year 1000

--- a/src/python/datapreprocessor/test/datanormaliser_tests.py
+++ b/src/python/datapreprocessor/test/datanormaliser_tests.py
@@ -157,3 +157,13 @@ class DataNormaliserTest(unittest.TestCase):
         normalised = normalise(test_data)
 
         self.assertEqual({'Year': 2012, 'Month': 1, 'Day': 13}, normalised[0][1])
+
+    def test_date_with_abbreviated_month_with_day_and_year(self):
+        
+        test_data = [
+            ['Minister name', '13 Jan 2012', 'People', 'Purpose']
+        ]
+
+        normalised = normalise(test_data)
+
+        self.assertEqual({'Year': 2012, 'Month': 1, 'Day': 13}, normalised[0][1])

--- a/src/python/datapreprocessor/test/datanormaliser_tests.py
+++ b/src/python/datapreprocessor/test/datanormaliser_tests.py
@@ -1,5 +1,5 @@
 import unittest
-from datapreprocessor.datanormaliser import normalise
+from datapreprocessor.datanormaliser import *
 
 class DataNormaliserTest(unittest.TestCase):
 
@@ -17,7 +17,7 @@ class DataNormaliserTest(unittest.TestCase):
         ]
 
         normalised = normalise(test_data)
-
+        print normalised[0][0]
         self.assertEqual(minister_name, normalised[0][0])
         self.assertEqual(minister_name, normalised[1][0])
         self.assertEqual(minister_name, normalised[2][0])
@@ -44,18 +44,18 @@ class DataNormaliserTest(unittest.TestCase):
 
         normalised = normalise(test_data)
 
-        self.assertEqual('2011-01-XX', normalised[0][1])
-        self.assertEqual('2011-02-XX', normalised[1][1])
-        self.assertEqual('2011-03-XX', normalised[2][1])
-        self.assertEqual('2011-04-XX', normalised[3][1])
-        self.assertEqual('2011-05-XX', normalised[4][1])
-        self.assertEqual('2011-06-XX', normalised[5][1])
-        self.assertEqual('2011-07-XX', normalised[6][1])
-        self.assertEqual('2011-08-XX', normalised[7][1])
-        self.assertEqual('2011-09-XX', normalised[8][1])
-        self.assertEqual('2011-10-XX', normalised[9][1])
-        self.assertEqual('2011-11-XX', normalised[10][1])
-        self.assertEqual('2011-12-XX', normalised[11][1])
+        self.assertEqual({'Year': 2011, 'Month': 1, 'Day': None}, normalised[0][1])
+        self.assertEqual({'Year': 2011, 'Month': 2, 'Day': None}, normalised[1][1])
+        self.assertEqual({'Year': 2011, 'Month': 3, 'Day': None}, normalised[2][1])
+        self.assertEqual({'Year': 2011, 'Month': 4, 'Day': None}, normalised[3][1])
+        self.assertEqual({'Year': 2011, 'Month': 5, 'Day': None}, normalised[4][1])
+        self.assertEqual({'Year': 2011, 'Month': 6, 'Day': None}, normalised[5][1])
+        self.assertEqual({'Year': 2011, 'Month': 7, 'Day': None}, normalised[6][1])
+        self.assertEqual({'Year': 2011, 'Month': 8, 'Day': None}, normalised[7][1])
+        self.assertEqual({'Year': 2011, 'Month': 9, 'Day': None}, normalised[8][1])
+        self.assertEqual({'Year': 2011, 'Month': 10, 'Day': None}, normalised[9][1])
+        self.assertEqual({'Year': 2011, 'Month': 11, 'Day': None}, normalised[10][1])
+        self.assertEqual({'Year': 2011, 'Month': 12, 'Day': None}, normalised[11][1])
 
     def test_date_which_have_whole_month_name_but_are_missing_years(self):
         test_data = [
@@ -75,19 +75,18 @@ class DataNormaliserTest(unittest.TestCase):
 
         normalised = normalise(test_data)
 
-        self.assertEqual('XXXX-01-XX', normalised[0][1])
-        self.assertEqual('XXXX-02-XX', normalised[1][1])
-        self.assertEqual('XXXX-03-XX', normalised[2][1])
-        self.assertEqual('XXXX-04-XX', normalised[3][1])
-        self.assertEqual('XXXX-05-XX', normalised[4][1])
-        self.assertEqual('XXXX-06-XX', normalised[5][1])
-        self.assertEqual('XXXX-07-XX', normalised[6][1])
-        self.assertEqual('XXXX-08-XX', normalised[7][1])
-        self.assertEqual('XXXX-09-XX', normalised[8][1])
-        self.assertEqual('XXXX-10-XX', normalised[9][1])
-        self.assertEqual('XXXX-11-XX', normalised[10][1])
-        self.assertEqual('XXXX-12-XX', normalised[11][1])
-
+        self.assertEqual({'Year': None, 'Month': 1, 'Day': None}, normalised[0][1])
+        self.assertEqual({'Year': None, 'Month': 2, 'Day': None}, normalised[1][1])
+        self.assertEqual({'Year': None, 'Month': 3, 'Day': None}, normalised[2][1])
+        self.assertEqual({'Year': None, 'Month': 4, 'Day': None}, normalised[3][1])
+        self.assertEqual({'Year': None, 'Month': 5, 'Day': None}, normalised[4][1])
+        self.assertEqual({'Year': None, 'Month': 6, 'Day': None}, normalised[5][1])
+        self.assertEqual({'Year': None, 'Month': 7, 'Day': None}, normalised[6][1])
+        self.assertEqual({'Year': None, 'Month': 8, 'Day': None}, normalised[7][1])
+        self.assertEqual({'Year': None, 'Month': 9, 'Day': None}, normalised[8][1])
+        self.assertEqual({'Year': None, 'Month': 10, 'Day': None}, normalised[9][1])
+        self.assertEqual({'Year': None, 'Month': 11, 'Day': None}, normalised[10][1])
+        self.assertEqual({'Year': None, 'Month': 12, 'Day': None}, normalised[11][1])
 
     def test_date_where_month_is_in_short_format(self):
         test_data = [
@@ -107,18 +106,18 @@ class DataNormaliserTest(unittest.TestCase):
 
         normalised = normalise(test_data)
 
-        self.assertEqual('XXXX-01-XX', normalised[0][1])
-        self.assertEqual('XXXX-02-XX', normalised[1][1])
-        self.assertEqual('XXXX-03-XX', normalised[2][1])
-        self.assertEqual('XXXX-04-XX', normalised[3][1])
-        self.assertEqual('XXXX-05-XX', normalised[4][1])
-        self.assertEqual('XXXX-06-XX', normalised[5][1])
-        self.assertEqual('XXXX-07-XX', normalised[6][1])
-        self.assertEqual('XXXX-08-XX', normalised[7][1])
-        self.assertEqual('XXXX-09-XX', normalised[8][1])
-        self.assertEqual('XXXX-10-XX', normalised[9][1])
-        self.assertEqual('XXXX-11-XX', normalised[10][1])
-        self.assertEqual('XXXX-12-XX', normalised[11][1])
+        self.assertEqual({'Year': None, 'Month': 1, 'Day': None}, normalised[0][1])
+        self.assertEqual({'Year': None, 'Month': 2, 'Day': None}, normalised[1][1])
+        self.assertEqual({'Year': None, 'Month': 3, 'Day': None}, normalised[2][1])
+        self.assertEqual({'Year': None, 'Month': 4, 'Day': None}, normalised[3][1])
+        self.assertEqual({'Year': None, 'Month': 5, 'Day': None}, normalised[4][1])
+        self.assertEqual({'Year': None, 'Month': 6, 'Day': None}, normalised[5][1])
+        self.assertEqual({'Year': None, 'Month': 7, 'Day': None}, normalised[6][1])
+        self.assertEqual({'Year': None, 'Month': 8, 'Day': None}, normalised[7][1])
+        self.assertEqual({'Year': None, 'Month': 9, 'Day': None}, normalised[8][1])
+        self.assertEqual({'Year': None, 'Month': 10, 'Day': None}, normalised[9][1])
+        self.assertEqual({'Year': None, 'Month': 11, 'Day': None}, normalised[10][1])
+        self.assertEqual({'Year': None, 'Month': 12, 'Day': None}, normalised[11][1])
 
     def test_date_where_month_is_sept(self):
         test_data = [
@@ -127,4 +126,24 @@ class DataNormaliserTest(unittest.TestCase):
 
         normalised = normalise(test_data)
 
-        self.assertEqual('XXXX-09-XX', normalised[0][1])
+        self.assertEqual({'Year': None, 'Month': 9, 'Day': None}, normalised[0][1])
+
+    def test_date_where_there_is_no_month_and_day(self):
+
+        test_data = [
+            ['Minister name', '2011', 'People', 'Purpose']
+        ]
+
+        normalised = normalise(test_data)
+
+        self.assertEqual({'Year': 2011, 'Month': None, 'Day': None}, normalised[0][1])
+
+    # def test_date_with_year_month_day(self):
+    #
+    #     test_data = [
+    #         ['Minister name', 'February 2011 13', 'People', 'Purpose']
+    #     ]
+    #
+    #     normalised = normalise(test_data)
+    #
+    #     self.assertEqual({'Year': 2011, 'Month': 2, 'Day': 13}, normalised[0][1])

--- a/src/python/datapreprocessor/test/datanormaliser_tests.py
+++ b/src/python/datapreprocessor/test/datanormaliser_tests.py
@@ -159,7 +159,7 @@ class DataNormaliserTest(unittest.TestCase):
         self.assertEqual({'Year': 2012, 'Month': 1, 'Day': 13}, normalised[0][1])
 
     def test_date_with_abbreviated_month_with_day_and_year(self):
-        
+
         test_data = [
             ['Minister name', '13 Jan 2012', 'People', 'Purpose']
         ]
@@ -167,3 +167,14 @@ class DataNormaliserTest(unittest.TestCase):
         normalised = normalise(test_data)
 
         self.assertEqual({'Year': 2012, 'Month': 1, 'Day': 13}, normalised[0][1])
+
+    def test_date_with_abbreviated_month_and_day(self):
+
+        test_data = [
+            # ['Minister name', '3 2012', 'People', 'Purpose'] assuming this is unlikely to be the date
+            ['Minister name', '3 Jan', 'People', 'Purpose']
+        ]
+
+        normalised = normalise(test_data)
+
+        self.assertEqual({'Year': None, 'Month': 1, 'Day': 3}, normalised[0][1])

--- a/src/python/datapreprocessor/test/datanormaliser_tests.py
+++ b/src/python/datapreprocessor/test/datanormaliser_tests.py
@@ -8,12 +8,12 @@ class DataNormaliserTest(unittest.TestCase):
         another_minister_name = "Frodo Baggins"
 
         test_data = [
-            [minister_name, 'A date', 'An attendee', 'A purpose'],
-            ['', 'A date', 'An attendee', 'A purpose'],
-            ['', 'A date', 'An attendee', 'A purpose'],
-            ['', 'A date', 'An attendee', 'A purpose'],
-            [another_minister_name, 'A date', 'An attendee', 'A purpose'],
-            ['', 'A date', 'An attendee', 'A purpose'],
+            [minister_name, 'Jan', 'An attendee', 'A purpose'],
+            ['', 'Jan', 'An attendee', 'A purpose'],
+            ['', 'Jan', 'An attendee', 'A purpose'],
+            ['', 'Jan', 'An attendee', 'A purpose'],
+            [another_minister_name, 'Jan', 'An attendee', 'A purpose'],
+            ['', 'Jan', 'An attendee', 'A purpose'],
         ]
 
         normalised = normalise(test_data)
@@ -138,12 +138,22 @@ class DataNormaliserTest(unittest.TestCase):
 
         self.assertEqual({'Year': 2011, 'Month': None, 'Day': None}, normalised[0][1])
 
-    # def test_date_with_year_month_day(self):
-    #
-    #     test_data = [
-    #         ['Minister name', 'February 2011 13', 'People', 'Purpose']
-    #     ]
-    #
-    #     normalised = normalise(test_data)
-    #
-    #     self.assertEqual({'Year': 2011, 'Month': 2, 'Day': 13}, normalised[0][1])
+    def test_date_when_there_is_no_date_info(self):
+
+        test_data = [
+            ['Minister name', '', 'People', 'Purpose']
+        ]
+
+        normalised = normalise(test_data)
+
+        self.assertEqual({'Year': None, 'Month': None, 'Day': None}, normalised[0][1])
+
+    def test_date_with_year_month_day(self):
+        #date has to be in format day month year
+        test_data = [
+            ['Minister name', '13 January 2012', 'People', 'Purpose']
+        ]
+
+        normalised = normalise(test_data)
+
+        self.assertEqual({'Year': 2012, 'Month': 1, 'Day': 13}, normalised[0][1])


### PR DESCRIPTION
## Issues to close

Fixes #<61>
## Notes

I have used a python dict here to separate date information to Year, Month and Day. If any one of these fields are not provided, it will return None.
