### PR TITLE
frontend: add repo meta-data to package.json

### DIFF
--- a/src/js/frontend/package.json
+++ b/src/js/frontend/package.json
@@ -1,5 +1,9 @@
 {
   "name": "muti-frontend",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/HackBrexit/MinistersUnderTheInfluence.git"
+  },
   "version": "1.0.0",
   "description": "Visualisations for the Ministers Under the Influence project",
   "main": "__build/muti-frontend.js",


### PR DESCRIPTION
This fixes a warning:

    npm WARN package.json muti-frontend@1.0.0 No repository field.