### PR TITLE
rails: enforce unique entity names

### DIFF
--- a/src/ruby/meetings/app/models/entity.rb
+++ b/src/ruby/meetings/app/models/entity.rb
@@ -3,7 +3,7 @@ class Entity < ApplicationRecord
     %w(Person Organisation GovernmentOffice)
   end
 
-  validates :name,presence: true
+  validates :name, presence: true
 
   self.types.each do |klass|
     scope klass.underscore.downcase.pluralize.to_sym,->{where(type: klass)}

--- a/src/ruby/meetings/app/models/government_office.rb
+++ b/src/ruby/meetings/app/models/government_office.rb
@@ -1,4 +1,6 @@
 class GovernmentOffice < Entity
+  validates :name, uniqueness: true
+
   # has_many :influence_government_office_people,-> { influence_government_office_people }, foreign_key: 'office_id',class_name:'InfluenceOfficePerson'
   has_many :influence_government_office_people, foreign_key: 'office_id'
   has_many :meetings,through: :influence_government_office_people,class_name: 'Meeting'

--- a/src/ruby/meetings/app/models/organisation.rb
+++ b/src/ruby/meetings/app/models/organisation.rb
@@ -1,4 +1,6 @@
 class Organisation < Entity
+  validates :name, uniqueness: true
+
   # has_many :influence_organisation_people,->{ influence_organisation_people },foreign_key: 'office_id',class_name:'InfluenceOfficePerson'
   has_many :influence_organisation_people,foreign_key: 'office_id'
   has_many :meetings,through: :influence_organisation_people,class_name: 'Meeting'

--- a/src/ruby/meetings/spec/models/entity_spec.rb
+++ b/src/ruby/meetings/spec/models/entity_spec.rb
@@ -7,31 +7,34 @@ RSpec.describe Entity, type: :model do
   it{ should validate_presence_of(:name)}
 end
 
-RSpec.describe Person,type: :model do
+RSpec.describe Person, type: :model do
   it{ should have_many(:influence_office_people)}
   it{ should have_many(:meetings).through(:influence_office_people)}
   it{ should have_many(:hospitalities).through(:influence_office_people)}
   it{ should have_many(:gifts).through(:influence_office_people)}
   it{ should have_many(:travels).through(:influence_office_people)}
+  it{ should_not validate_uniqueness_of(:name) }
 end
 
-RSpec.describe Organisation,type: :model do
+RSpec.describe Organisation, type: :model do
   it{ should have_many(:influence_organisation_people)}
   it{ should have_many(:meetings).through(:influence_organisation_people)}
   it{ should have_many(:hospitalities).through(:influence_organisation_people)}
   it{ should have_many(:gifts).through(:influence_organisation_people)}
   it{ should have_many(:travels).through(:influence_organisation_people)}
+  it{ should validate_uniqueness_of(:name) }
 end
 
-RSpec.describe GovernmentOffice,type: :model do
+RSpec.describe GovernmentOffice, type: :model do
   it{ should have_many(:influence_government_office_people)}
   it{ should have_many(:meetings).through(:influence_government_office_people)}
   it{ should have_many(:hospitalities).through(:influence_government_office_people)}
   it{ should have_many(:gifts).through(:influence_government_office_people)}
   it{ should have_many(:travels).through(:influence_government_office_people)}
+  it{ should validate_uniqueness_of(:name) }
 end
 
-RSpec.describe Entity,type: :model do
+RSpec.describe Entity, type: :model do
   context 'the class' do
     subject{Entity}
     Entity.types.each do |entity_type|

--- a/src/ruby/meetings/spec/models/entity_spec.rb
+++ b/src/ruby/meetings/spec/models/entity_spec.rb
@@ -1,37 +1,37 @@
 require 'rails_helper'
 
 RSpec.describe Entity, type: :model do
-  it{ should have_db_column(:type).of_type(:string)}
-  it{ should have_db_column(:name).of_type(:string)}
-  it{ should have_db_column(:wikipedia_entry).of_type(:string)}
-  it{ should validate_presence_of(:name)}
+  it { should have_db_column(:type).of_type(:string) }
+  it { should have_db_column(:name).of_type(:string) }
+  it { should have_db_column(:wikipedia_entry).of_type(:string) }
+  it { should validate_presence_of(:name) }
 end
 
 RSpec.describe Person, type: :model do
-  it{ should have_many(:influence_office_people)}
-  it{ should have_many(:meetings).through(:influence_office_people)}
-  it{ should have_many(:hospitalities).through(:influence_office_people)}
-  it{ should have_many(:gifts).through(:influence_office_people)}
-  it{ should have_many(:travels).through(:influence_office_people)}
-  it{ should_not validate_uniqueness_of(:name) }
+  it { should have_many(:influence_office_people) }
+  it { should have_many(:meetings).through(:influence_office_people) }
+  it { should have_many(:hospitalities).through(:influence_office_people) }
+  it { should have_many(:gifts).through(:influence_office_people) }
+  it { should have_many(:travels).through(:influence_office_people) }
+  it { should_not validate_uniqueness_of(:name) }
 end
 
 RSpec.describe Organisation, type: :model do
-  it{ should have_many(:influence_organisation_people)}
-  it{ should have_many(:meetings).through(:influence_organisation_people)}
-  it{ should have_many(:hospitalities).through(:influence_organisation_people)}
-  it{ should have_many(:gifts).through(:influence_organisation_people)}
-  it{ should have_many(:travels).through(:influence_organisation_people)}
-  it{ should validate_uniqueness_of(:name) }
+  it { should have_many(:influence_organisation_people) }
+  it { should have_many(:meetings).through(:influence_organisation_people) }
+  it { should have_many(:hospitalities).through(:influence_organisation_people) }
+  it { should have_many(:gifts).through(:influence_organisation_people) }
+  it { should have_many(:travels).through(:influence_organisation_people) }
+  it { should validate_uniqueness_of(:name) }
 end
 
 RSpec.describe GovernmentOffice, type: :model do
-  it{ should have_many(:influence_government_office_people)}
-  it{ should have_many(:meetings).through(:influence_government_office_people)}
-  it{ should have_many(:hospitalities).through(:influence_government_office_people)}
-  it{ should have_many(:gifts).through(:influence_government_office_people)}
-  it{ should have_many(:travels).through(:influence_government_office_people)}
-  it{ should validate_uniqueness_of(:name) }
+  it { should have_many(:influence_government_office_people) }
+  it { should have_many(:meetings).through(:influence_government_office_people) }
+  it { should have_many(:hospitalities).through(:influence_government_office_people) }
+  it { should have_many(:gifts).through(:influence_government_office_people) }
+  it { should have_many(:travels).through(:influence_government_office_people) }
+  it { should validate_uniqueness_of(:name) }
 end
 
 RSpec.describe Entity, type: :model do


### PR DESCRIPTION
This should prevent having multiple records for people, organisations, etc. with the same name.

I am not 100% sure if this is correct; would appreciate reviews especially from @JohnSmall and @Greatlemer ;-)