### PR TITLE
api: allow day attribute for means of influence

### DIFF
--- a/src/ruby/meetings/app/resources/api/v1/means_of_influence_resource.rb
+++ b/src/ruby/meetings/app/resources/api/v1/means_of_influence_resource.rb
@@ -1,5 +1,5 @@
 class Api::V1::MeansOfInfluenceResource < JSONAPI::Resource
   # attributes :year,:month,:source_file_id,:source_file_line_number
-  attributes :year,:month,:source_file_id,:source_file_line_number
+  attributes :year, :month, :day, :source_file_id, :source_file_line_number
   has_one :source_file
 end


### PR DESCRIPTION
The day attribute is in the means of influence model, but it wasn't being allowed via the JSON API.