### PR TITLE
ui: drop superfluous marginLeft

### DIFF
--- a/src/js/frontend/src/components/Logo.js
+++ b/src/js/frontend/src/components/Logo.js
@@ -25,7 +25,6 @@ var styles = {
   base: {
     fontWeight: 'lighter',
     float: 'left',
-    marginLeft: '20px',
     display: 'inline',
     lineHeight: "12vh",
     color: '#119DA4',


### PR DESCRIPTION
This clashes with the margin style from the same place and causes a warning in the browser console.