### PR TITLE
rails: fix organisation_side decorator for means of influence

### DIFF
--- a/src/ruby/meetings/app/decorators/means_of_influence_decorator.rb
+++ b/src/ruby/meetings/app/decorators/means_of_influence_decorator.rb
@@ -16,7 +16,9 @@ class MeansOfInfluenceDecorator < Draper::Decorator
   def organisation_side
      influence_organisation_people.map do |ip|
        if ip.person
-         "#{ip.organisation.name}: #{ip.person.name}"
+         organisation_name = ip.organisation.try(:name)
+         person_name = ip.person.try(:name)
+         [organisation_name, person_name].compact.join ": "
        else
          ip.organisation.name
        end


### PR DESCRIPTION
Sometimes a meeting will not have both an organisation *and* a representative from that organisation, so we avoid crashes resulting from trying to call the `#name` method on `nil`.

This is exactly the same issue and approach as in 3e1f561c97d.