### PR TITLE
ui: display entity names about bubble charts

### DIFF
--- a/src/js/frontend/src/Redux/action-types.js
+++ b/src/js/frontend/src/Redux/action-types.js
@@ -1,1 +1,2 @@
 export const TOGGLE_ABOUT = "TOGGLE_ABOUT"
+export const ADD_ENTITY = "ADD_ENTITY"

--- a/src/js/frontend/src/Redux/actions.js
+++ b/src/js/frontend/src/Redux/actions.js
@@ -1,6 +1,8 @@
 import * as actionTypes from "./action-types"
 
-// example of a regular action
+// These are action creators
+// http://redux.js.org/docs/basics/Actions.html#action-creators
+
 export const toggleAbout = () => {
   return {
     type: actionTypes.TOGGLE_ABOUT,

--- a/src/js/frontend/src/Redux/actions.js
+++ b/src/js/frontend/src/Redux/actions.js
@@ -8,3 +8,12 @@ export const toggleAbout = () => {
     type: actionTypes.TOGGLE_ABOUT,
   }
 }
+
+export const addEntity = (entityType, id, data) => {
+  return {
+    type: actionTypes.ADD_ENTITY,
+    entityType,
+    id,
+    data,
+  }
+}

--- a/src/js/frontend/src/Redux/reducer.js
+++ b/src/js/frontend/src/Redux/reducer.js
@@ -4,6 +4,9 @@ import * as actionTypes from "./action-types";
 ////////////////////////////////////////////////////////////////////////////////
 // root reducer
 
+// FIXME: switch to use combineReducers?
+// http://redux.js.org/docs/api/combineReducers.html
+
 export function rootReducer (state = IMap(), action) {
   return state.merge({
     showAboutScreen: aboutReducer(state.get("showAboutScreen", undefined),

--- a/src/js/frontend/src/Redux/reducer.js
+++ b/src/js/frontend/src/Redux/reducer.js
@@ -11,6 +11,7 @@ export function rootReducer (state = IMap(), action) {
   return state.merge({
     showAboutScreen: aboutReducer(state.get("showAboutScreen", undefined),
                                   action),
+    entities: addEntityReducer(state.get("entities"), action),
   })
   return state;
 }
@@ -24,12 +25,36 @@ export function rootReducer (state = IMap(), action) {
 
 const defaultState = {
   showAboutScreen: false,
+  entities: {
+    people: {},
+    organisations: {},
+    "government-offices": {},
+  },
 };
 
 function aboutReducer(state = defaultState.showAboutScreen, {type}) {
   switch (type) {
     case actionTypes.TOGGLE_ABOUT:
       return !state;
+    default:
+      return state;
+  }
+}
+
+function addEntityReducer(state = defaultState.entities, action) {
+  let {type, entityType, id, data} = action;
+
+  switch (type) {
+    case actionTypes.ADD_ENTITY:
+      if (!state.has(entityType)) {
+        console.error(`Received ADD_ENTITY action with invalid entity type ${entityType}`);
+        return state;
+      }
+      return state.mergeDeep({
+        [entityType]: {
+          [id]: data
+        },
+      });
     default:
       return state;
   }

--- a/src/js/frontend/src/Redux/reducer.js
+++ b/src/js/frontend/src/Redux/reducer.js
@@ -6,7 +6,8 @@ import * as actionTypes from "./action-types";
 
 export function rootReducer (state = IMap(), action) {
   return state.merge({
-    showAboutScreen: aboutReducer(state.get("showAboutScreen", undefined), action),
+    showAboutScreen: aboutReducer(state.get("showAboutScreen", undefined),
+                                  action),
   })
   return state;
 }
@@ -22,14 +23,11 @@ const defaultState = {
   showAboutScreen: false,
 };
 
-export function aboutReducer(state = defaultState, {type}) {
-  let newState = Object.assign({}, state);
-
+export function aboutReducer(state = defaultState.showAboutScreen, {type}) {
   switch (type) {
     case actionTypes.TOGGLE_ABOUT:
-      newState.showAboutScreen = !newState.showAboutScreen;
-      return newState;
+      return !state;
     default:
-      return newState;
+      return state;
   }
 }

--- a/src/js/frontend/src/Redux/reducer.js
+++ b/src/js/frontend/src/Redux/reducer.js
@@ -26,7 +26,7 @@ const defaultState = {
   showAboutScreen: false,
 };
 
-export function aboutReducer(state = defaultState.showAboutScreen, {type}) {
+function aboutReducer(state = defaultState.showAboutScreen, {type}) {
   switch (type) {
     case actionTypes.TOGGLE_ABOUT:
       return !state;

--- a/src/js/frontend/src/Redux/reducer.js
+++ b/src/js/frontend/src/Redux/reducer.js
@@ -13,7 +13,6 @@ export function rootReducer (state = IMap(), action) {
                                   action),
     entities: addEntityReducer(state.get("entities"), action),
   })
-  return state;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/js/frontend/src/Redux/store.js
+++ b/src/js/frontend/src/Redux/store.js
@@ -1,0 +1,43 @@
+import immutableStorageDecorator from "./immutable-storage-decorator"
+import {createStore, applyMiddleware} from "redux"
+import thunkMiddleware from "redux-thunk"
+import createLogger from 'redux-logger'
+import {rootReducer, aboutReducer} from "./reducer"
+import * as storage from "redux-storage"
+import createEngine from "redux-storage-engine-localstorage"
+import storageDebounce from 'redux-storage-decorator-debounce'
+
+////////////////////////////////////////////////////////////////////////////////
+// redux stuff
+
+// wrap our main reducer in a storage reducer - this intercepts LOAD actions and
+// calls the merger function to merge in the new state
+const reducer = storage.reducer(rootReducer, (oldState, newState) => newState)
+// const reducer = aboutReducer;
+
+// create a storage engine, with decorators to convert plain JS into Immutable
+// and "debounce" storage so it's not happening all the time
+const engine = storageDebounce(immutableStorageDecorator(createEngine("muti-frontend")), 2000)
+// create storage middleware, which triggers a save action after every normal action
+const storageMiddleware = storage.createMiddleware(engine)
+// create logger middleware
+const loggerMiddleware = createLogger({
+  stateTransformer: (state) => state.toJS(),
+  // you can filter out certain actions from logging
+  //predicate: (getState, action) => action.type !== CALCULATION_NEEDS_REFRESH
+})
+
+// now create our redux store, applying all our middleware
+// const store = createStore(reducer, applyMiddleware(
+//   thunkMiddleware, // first, so function results get transformed
+//   loggerMiddleware, // now log everything at this state
+//   storageMiddleware // finally the storage middleware
+// ))
+
+
+const store = createStore(
+  reducer,
+  window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
+);
+
+module.exports = {store, engine};

--- a/src/js/frontend/src/Redux/store.js
+++ b/src/js/frontend/src/Redux/store.js
@@ -2,7 +2,7 @@ import immutableStorageDecorator from "./immutable-storage-decorator"
 import {createStore, applyMiddleware} from "redux"
 import thunkMiddleware from "redux-thunk"
 import createLogger from 'redux-logger'
-import {rootReducer, aboutReducer} from "./reducer"
+import {rootReducer} from "./reducer"
 import * as storage from "redux-storage"
 import createEngine from "redux-storage-engine-localstorage"
 import storageDebounce from 'redux-storage-decorator-debounce'
@@ -13,7 +13,6 @@ import storageDebounce from 'redux-storage-decorator-debounce'
 // wrap our main reducer in a storage reducer - this intercepts LOAD actions and
 // calls the merger function to merge in the new state
 const reducer = storage.reducer(rootReducer, (oldState, newState) => newState)
-// const reducer = aboutReducer;
 
 // create a storage engine, with decorators to convert plain JS into Immutable
 // and "debounce" storage so it's not happening all the time

--- a/src/js/frontend/src/Redux/store.js
+++ b/src/js/frontend/src/Redux/store.js
@@ -21,7 +21,7 @@ const engine = storageDebounce(immutableStorageDecorator(createEngine("muti-fron
 const storageMiddleware = storage.createMiddleware(engine)
 // create logger middleware
 const loggerMiddleware = createLogger({
-  stateTransformer: (state) => state.toJS(),
+  //stateTransformer: (state) => state.toJS ? state.toJS() : state,
   // you can filter out certain actions from logging
   //predicate: (getState, action) => action.type !== CALCULATION_NEEDS_REFRESH
 })

--- a/src/js/frontend/src/components/Chart.js
+++ b/src/js/frontend/src/components/Chart.js
@@ -13,13 +13,23 @@ let Chart = React.createClass({
     data: React.PropTypes.object,
     sourceType: React.PropTypes.string.isRequired,
     sourceId: React.PropTypes.string,
+    sourceName: React.PropTypes.string,
     targetType: React.PropTypes.string,
   },
 
   render: function() {
+    let description = this.props.sourceName ?
+        <p style={{width: "50%", display: "inline"}}>
+          Showing all meetings with {this.props.sourceName}
+        </p>
+      : "";
+
     return (
       <div>
-        <Link to="/">Back to home</Link>
+        <div>
+          {description}
+          <Link style={{float: "right"}} to="/">Back to home</Link>
+        </div>
         <div
           style={[
             styles.base,

--- a/src/js/frontend/src/components/Chart.js
+++ b/src/js/frontend/src/components/Chart.js
@@ -33,6 +33,10 @@ let Chart = React.createClass({
     )
   },
 
+  shouldComponentUpdate: function() {
+    return false;
+  },
+
   componentDidMount: function() {
     this.getData();
   },

--- a/src/js/frontend/src/components/Chart.js
+++ b/src/js/frontend/src/components/Chart.js
@@ -18,29 +18,17 @@ let Chart = React.createClass({
   },
 
   render: function() {
-    let description = this.props.sourceName ?
-        <p style={{width: "50%", display: "inline"}}>
-          Showing all meetings with {this.props.sourceName}
-        </p>
-      : "";
-
     return (
-      <div>
-        <div>
-          {description}
-          <Link style={{float: "right"}} to="/">Back to home</Link>
-        </div>
-        <div
-          style={[
-            styles.base,
-          ]}
-          className="chart" ref="topdiv">
-          <svg className="d3" ref="svg"
-               width={this.props.width}
-               height={this.props.height}>
-            <g className="d3-points" />
-          </svg>
-        </div>
+      <div
+        style={[
+          styles.base,
+        ]}
+        className="chart" ref="topdiv">
+        <svg className="d3" ref="svg"
+             width={this.props.width}
+             height={this.props.height}>
+          <g className="d3-points" />
+        </svg>
       </div>
     )
   },

--- a/src/js/frontend/src/components/Chart.js
+++ b/src/js/frontend/src/components/Chart.js
@@ -1,6 +1,7 @@
 import React from "react"
 import ReactDOM from "react-dom"
 import Radium from "radium"
+import { Link } from 'react-router'
 
 let d3Chart = require('./d3Chart');
 let meetingData = require('./meetingData');
@@ -17,16 +18,19 @@ let Chart = React.createClass({
 
   render: function() {
     return (
-      <div
-        style={[
-          styles.base,
-        ]}
-        className="chart" ref="topdiv">
-        <svg className="d3" ref="svg"
-             width={this.props.width}
-             height={this.props.height}>
-          <g className="d3-points" />
-        </svg>
+      <div>
+        <Link to="/">Back to home</Link>
+        <div
+          style={[
+            styles.base,
+          ]}
+          className="chart" ref="topdiv">
+          <svg className="d3" ref="svg"
+               width={this.props.width}
+               height={this.props.height}>
+            <g className="d3-points" />
+          </svg>
+        </div>
       </div>
     )
   },

--- a/src/js/frontend/src/components/ChartTitle.js
+++ b/src/js/frontend/src/components/ChartTitle.js
@@ -6,7 +6,7 @@ import { Link } from 'react-router'
 function ChartTitle (props) {
   let description = props.sourceName ?
       <p style={{width: "50%", display: "inline"}}>
-        Showing all meetings with {props.sourceName}
+        Showing all meetings of {props.targetType} with {props.sourceName}
       </p>
     : "";
 

--- a/src/js/frontend/src/components/ChartTitle.js
+++ b/src/js/frontend/src/components/ChartTitle.js
@@ -1,0 +1,25 @@
+import React from "react"
+import ReactDOM from "react-dom"
+import Radium from "radium"
+import { Link } from 'react-router'
+
+function ChartTitle (props) {
+  let description = props.sourceName ?
+      <p style={{width: "50%", display: "inline"}}>
+        Showing all meetings with {props.sourceName}
+      </p>
+    : "";
+
+  return (
+    <div>
+      {description}
+      <Link style={{float: "right"}} to="/">Back to home</Link>
+    </div>
+  )
+}
+
+ChartTitle.propTypes = {
+  sourceName: React.PropTypes.string,
+};
+
+module.exports = Radium(ChartTitle);

--- a/src/js/frontend/src/components/d3Chart.js
+++ b/src/js/frontend/src/components/d3Chart.js
@@ -104,12 +104,13 @@ let d3Chart = {
     this.bubbles.append("text")
       .text(function(d) {return d.targetName;})
       .style("font-size", this.bubbleTextFontSize)
+      .style("font-weight", "bold")
   },
 
   bubbleTextFontSize: function(d) {
     return Math.min(
       2 * d.radius,
-      (2 * d.radius - 8) / this.getComputedTextLength() * 10
+      (2 * d.radius - 8) / this.getComputedTextLength() * 15
     ) + "px";
   },
 

--- a/src/js/frontend/src/components/d3Chart.js
+++ b/src/js/frontend/src/components/d3Chart.js
@@ -28,10 +28,10 @@ let d3Chart = {
   },
 
   initBubbleCoordsRadius: function(svg, data) {
-    for (let i = 0; i < data.length; i++) {
-      data[i].radius = Math.sqrt(data[i].meetingCount) * RADIUS_SCALE;
-      data[i].x = Math.random() * svg.pixelWidth;
-      data[i].y = Math.random() * svg.pixelHeight;
+    data.each((item) => {
+      item.radius = Math.sqrt(item.meetingCount) * RADIUS_SCALE;
+      item.x = Math.random() * svg.pixelWidth;
+      item.y = Math.random() * svg.pixelHeight;
     }
   },
 

--- a/src/js/frontend/src/components/d3Chart.js
+++ b/src/js/frontend/src/components/d3Chart.js
@@ -4,7 +4,7 @@
 // them.
 
 // FIXME: make this constant configurable
-let RADIUS_SCALE = 10;
+let RADIUS_SCALE = 25;
 
 let d3 = require('d3');
 let meetingData = require('./meetingData');
@@ -29,7 +29,7 @@ let d3Chart = {
 
   initBubbleCoordsRadius: function(svg, data) {
     for (let i = 0; i < data.length; i++) {
-      data[i].radius = data[i].meetingCount * RADIUS_SCALE;
+      data[i].radius = Math.sqrt(data[i].meetingCount) * RADIUS_SCALE;
       data[i].x = Math.random() * svg.pixelWidth;
       data[i].y = Math.random() * svg.pixelHeight;
     }

--- a/src/js/frontend/src/components/entityData.js
+++ b/src/js/frontend/src/components/entityData.js
@@ -1,0 +1,44 @@
+let d3 = require('d3');
+let api = require('./api');
+
+let entityData = {
+  fetch: function(entityType, entityId, onSuccess) {
+    let url = this.apiURL(entityType, entityId);
+    console.debug("Fetching from " + url);
+    d3.request(url)
+      .mimeType("application/json")
+      .header("Accept", "application/vnd.api+json")
+      .response(function(xhr) { return JSON.parse(xhr.responseText); })
+      .get(this.dataLoadedHandler(onSuccess, url, entityType, entityId));
+  },
+
+  apiURL: function(entityType, entityId) {
+    return api.URL(entityType + "/" + entityId);
+  },
+
+  dataLoadedHandler: function(onSuccess, url, entityType, entityId) {
+    let self = this;
+
+    return function(error, json) {
+      if (error) {
+        // FIXME: make this more elegant
+        let msg = "Error fetching data from " + url + ": " + error;
+        alert(msg);
+        console.error(msg);
+        return;
+      }
+
+      if (json.data.length === 0) {
+        let msg = "Didn't find any meetings for " + entityType +
+            " with id " + entityId;
+        alert(msg);
+        console.warn(msg + " via " + url);
+        return;
+      }
+
+      onSuccess(json);
+    };
+  },
+}
+
+module.exports = entityData;

--- a/src/js/frontend/src/components/meetingData.js
+++ b/src/js/frontend/src/components/meetingData.js
@@ -23,7 +23,7 @@ let meetingData = {
 
   fetch: function(sourceType, sourceId, targetType, onSuccess) {
     let url = this.apiURL(sourceType, sourceId, targetType);
-    console.log("Fetching from " + url);
+    console.debug("Fetching from " + url);
     d3.request(url)
       .mimeType("application/json")
       .header("Accept", "application/vnd.api+json")

--- a/src/js/frontend/src/containers/ChartContainer.js
+++ b/src/js/frontend/src/containers/ChartContainer.js
@@ -2,6 +2,7 @@ import React from "react"
 import Radium from "radium"
 import { connect } from 'react-redux';
 
+import ChartTitle from "../components/ChartTitle"
 import Chart from "../components/Chart"
 import entityData from "../components/entityData"
 import * as actions from "../Redux/actions"
@@ -20,9 +21,9 @@ class ChartContainer extends React.Component {
     let entityName = entityData && entityData.get("name");
 
     return <div className="chart-container">
+      <ChartTitle sourceName={entityName} />
       <Chart width="100%" height="100%"
              sourceType={sourceType}
-             sourceName={entityName}
              sourceId={id}
              targetType={this.props.params.targetType} />
     </div>

--- a/src/js/frontend/src/containers/ChartContainer.js
+++ b/src/js/frontend/src/containers/ChartContainer.js
@@ -9,7 +9,9 @@ import * as actions from "../Redux/actions"
 
 class ChartContainer extends React.Component {
   componentWillMount () {
-    this.getEntityName()
+    if (this.props.route.sourceType !== "demo") {
+      this.getEntityName()
+    }
   }
 
   render () {

--- a/src/js/frontend/src/containers/ChartContainer.js
+++ b/src/js/frontend/src/containers/ChartContainer.js
@@ -1,13 +1,11 @@
 import React from "react"
 import Radium from "radium"
-import { Link } from 'react-router'
 
 let Chart = require('../components/Chart');
 
 class ChartContainer extends React.Component {
   render () {
     return <div className="chart-container">
-      <Link to="/">Back to home</Link>
       <Chart width="100%" height="100%"
              sourceType={this.props.route.sourceType}
              sourceId={this.props.params.id}

--- a/src/js/frontend/src/containers/ChartContainer.js
+++ b/src/js/frontend/src/containers/ChartContainer.js
@@ -1,17 +1,54 @@
 import React from "react"
 import Radium from "radium"
+import { connect } from 'react-redux';
 
-let Chart = require('../components/Chart');
+import Chart from "../components/Chart"
+import entityData from "../components/entityData"
+import * as actions from "../Redux/actions"
 
 class ChartContainer extends React.Component {
+  componentWillMount () {
+    this.getEntityName()
+  }
+
   render () {
+    let sourceType = this.props.route.sourceType;
+    let id = this.props.params.id;
+    let entities = this.props.entities; // comes in via mapStateToProps
+    let sourceData = entities && entities.get(sourceType);
+    let entityData = sourceData && sourceData.get(id);
+    let entityName = entityData && entityData.get("name");
+
     return <div className="chart-container">
       <Chart width="100%" height="100%"
-             sourceType={this.props.route.sourceType}
-             sourceId={this.props.params.id}
+             sourceType={sourceType}
+             sourceName={entityName}
+             sourceId={id}
              targetType={this.props.params.targetType} />
     </div>
   }
+
+  getEntityName () {
+    entityData.fetch(
+      this.props.route.sourceType,
+      this.props.params.id,
+      (json) => {
+        let action = actions.addEntity(
+          this.props.route.sourceType,
+          this.props.params.id,
+          json.data.attributes
+        );
+        this.props.dispatch(action);
+      }
+    )
+  }
 }
 
-export default Radium(ChartContainer);
+const mapStateToProps = (state) => {
+  return {
+    entities: state.get("entities"),
+  };
+};
+
+export default connect(mapStateToProps)(Radium(ChartContainer));
+

--- a/src/js/frontend/src/containers/ChartContainer.js
+++ b/src/js/frontend/src/containers/ChartContainer.js
@@ -14,6 +14,7 @@ class ChartContainer extends React.Component {
 
   render () {
     let sourceType = this.props.route.sourceType;
+    let targetType = this.props.params.targetType;
     let id = this.props.params.id;
     let entities = this.props.entities; // comes in via mapStateToProps
     let sourceData = entities && entities.get(sourceType);
@@ -21,11 +22,12 @@ class ChartContainer extends React.Component {
     let entityName = entityData && entityData.get("name");
 
     return <div className="chart-container">
-      <ChartTitle sourceName={entityName} />
+      <ChartTitle sourceName={entityName}
+                  targetType={targetType} />
       <Chart width="100%" height="100%"
              sourceType={sourceType}
              sourceId={id}
-             targetType={this.props.params.targetType} />
+             targetType={targetType} />
     </div>
   }
 

--- a/src/js/frontend/src/main.js
+++ b/src/js/frontend/src/main.js
@@ -43,7 +43,10 @@ const loggerMiddleware = createLogger({
 // ))
 
 
-const store = createStore(aboutReducer, window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__());
+const store = createStore(
+  reducer,
+  window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
+);
 
 // now everything is set up, create a loader and use it to load the store
 const load = storage.createLoader(engine)

--- a/src/js/frontend/src/main.js
+++ b/src/js/frontend/src/main.js
@@ -1,59 +1,20 @@
 import React from "react"
 import ReactDOM from "react-dom"
-import App from "./app"
-import {Router, Route, IndexRoute, hashHistory} from 'react-router'
-import immutableStorageDecorator from "./Redux/immutable-storage-decorator"
-import {createStore, applyMiddleware} from "redux"
 import {Provider} from "react-redux"
-import thunkMiddleware from "redux-thunk"
-import {rootReducer, aboutReducer} from "./Redux/reducer"
+import {Router, Route, IndexRoute, hashHistory} from 'react-router'
 import * as storage from "redux-storage"
-import createEngine from "redux-storage-engine-localstorage"
-import storageDebounce from 'redux-storage-decorator-debounce'
-import createLogger from 'redux-logger'
+
+import {store, engine} from "./Redux/store"
+import App from "./app"
 import PageLayout from "./containers/PageLayout"
 import Home from "./components/Home"
 import ChartContainer from "./containers/ChartContainer"
-
-////////////////////////////////////////////////////////////////////////////////
-// redux stuff
-
-// wrap our main reducer in a storage reducer - this intercepts LOAD actions and
-// calls the merger function to merge in the new state
-const reducer = storage.reducer(rootReducer, (oldState, newState) => newState)
-// const reducer = aboutReducer;
-
-// create a storage engine, with decorators to convert plain JS into Immutable
-// and "debounce" storage so it's not happening all the time
-const engine = storageDebounce(immutableStorageDecorator(createEngine("muti-frontend")), 2000)
-// create storage middleware, which triggers a save action after every normal action
-const storageMiddleware = storage.createMiddleware(engine)
-// create logger middleware
-const loggerMiddleware = createLogger({
-  stateTransformer: (state) => state.toJS(),
-  // you can filter out certain actions from logging
-  //predicate: (getState, action) => action.type !== CALCULATION_NEEDS_REFRESH
-})
-
-// now create our redux store, applying all our middleware
-// const store = createStore(reducer, applyMiddleware(
-//   thunkMiddleware, // first, so function results get transformed
-//   loggerMiddleware, // now log everything at this state
-//   storageMiddleware // finally the storage middleware
-// ))
-
-
-const store = createStore(
-  reducer,
-  window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
-);
 
 // now everything is set up, create a loader and use it to load the store
 const load = storage.createLoader(engine)
 const loaded = load(store)
 loaded.then((newState) => {
 
-  ////////////////////////////////////////////////////////////////////////////////
   // render a router into the page
 
   ReactDOM.render(


### PR DESCRIPTION
For example, if you select a URL to show all meetings of government ministers with BAE Systems, then the bubble chart will be entitled "Showing all meetings of government-people with BAE Systems".

## Issues to close

Fixes #142

## Notes

This queries the API for the entity name, and then uses Redux to store it in the app store for use by the `ChartContainer` component.  In the future we'll want also to switch the d3Chart API call to use Redux.